### PR TITLE
feat(#12): UI 개선 및 다크모드 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,3 +38,28 @@ body {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
 }
+
+/* Custom Scrollbar Styles */
+.scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 3px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background-color: var(--border);
+  border-radius: 3px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background-color: var(--muted-foreground);
+}

--- a/src/app/weather/[id]/page.tsx
+++ b/src/app/weather/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useFavoritesStore } from "@/shared/model/favoritesStore";
 import { useCurrentWeather, useHourlyForecast } from "@/features/weather";
 import { WeatherCard } from "@/widgets/weather-card";
 import { HourlyForecast } from "@/widgets/hourly-forecast";
-import { Button } from "@/shared/ui";
+import { Button, ThemeToggle } from "@/shared/ui";
 import { ArrowLeft, Loader2 } from "lucide-react";
 
 interface PageProps {
@@ -33,7 +33,7 @@ export default function WeatherDetailPage({ params }: PageProps) {
 
   if (!favorite) {
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 bg-[var(--background)]">
         <p className="text-lg text-[var(--muted-foreground)]">
           즐겨찾기를 찾을 수 없습니다.
         </p>
@@ -49,7 +49,7 @@ export default function WeatherDetailPage({ params }: PageProps) {
 
   if (isLoading) {
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-4">
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-[var(--background)]">
         <Loader2 className="w-10 h-10 text-[var(--muted-foreground)] animate-spin" />
         <p className="text-[var(--muted-foreground)]">날씨 정보 불러오는 중...</p>
       </main>
@@ -57,17 +57,19 @@ export default function WeatherDetailPage({ params }: PageProps) {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center p-4 md:p-8 gap-4">
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-8 gap-4 bg-[var(--background)]">
       <div className="w-full max-w-md">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => router.push("/")}
-          className="mb-4"
-        >
-          <ArrowLeft className="w-4 h-4 mr-2" />
-          돌아가기
-        </Button>
+        <div className="flex items-center justify-between mb-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push("/")}
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            돌아가기
+          </Button>
+          <ThemeToggle />
+        </div>
 
         {weather && (
           <WeatherCard

--- a/src/features/location-search/ui/LocationSearch.tsx
+++ b/src/features/location-search/ui/LocationSearch.tsx
@@ -126,7 +126,7 @@ export function LocationSearch({
 
       {/* 검색 결과 드롭다운 */}
       {isOpen && results.length > 0 && (
-        <div className="absolute z-50 w-full mt-1 bg-[var(--card)] border border-[var(--border)] rounded-md shadow-lg max-h-64 overflow-y-auto">
+        <div className="absolute z-50 w-full mt-1 bg-[var(--card)] border border-[var(--border)] rounded-md shadow-lg max-h-64 overflow-y-auto scrollbar-thin">
           {results.map((location, index) => (
             <button
               key={location.id}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -2,3 +2,4 @@ export * from "./button";
 export * from "./card";
 export * from "./input";
 export * from "./skeleton";
+export * from "./theme-toggle";

--- a/src/shared/ui/theme-toggle.tsx
+++ b/src/shared/ui/theme-toggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { Button } from "./button";
+import { useThemeStore } from "@/shared/model/themeStore";
+
+export function ThemeToggle() {
+  const { resolvedTheme, toggleTheme } = useThemeStore();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      title={resolvedTheme === "dark" ? "라이트 모드로 전환" : "다크 모드로 전환"}
+      className="bg-white/20 hover:bg-white/30 backdrop-blur-sm"
+    >
+      {resolvedTheme === "dark" ? (
+        <Sun className="w-5 h-5 text-yellow-300" />
+      ) : (
+        <Moon className="w-5 h-5" />
+      )}
+    </Button>
+  );
+}

--- a/src/widgets/favorite-grid/ui/DeleteConfirmModal.tsx
+++ b/src/widgets/favorite-grid/ui/DeleteConfirmModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Button } from "@/shared/ui";
+import { X, AlertTriangle } from "lucide-react";
+import type { FavoriteLocation } from "@/shared/model/favoritesStore";
+
+interface DeleteConfirmModalProps {
+  favorite: FavoriteLocation | null;
+  onClose: () => void;
+  onConfirm: (id: string) => void;
+}
+
+export function DeleteConfirmModal({ favorite, onClose, onConfirm }: DeleteConfirmModalProps) {
+  if (!favorite) return null;
+
+  const handleConfirm = () => {
+    onConfirm(favorite.id);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-[var(--card)] border border-[var(--border)] rounded-lg shadow-lg w-full max-w-sm mx-4 p-4">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <AlertTriangle className="w-5 h-5 text-red-500" />
+            삭제 확인
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-[var(--accent)] rounded"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <p className="text-[var(--muted-foreground)] mb-4">
+          <span className="font-medium text-[var(--foreground)]">{favorite.name}</span>
+          을(를) 즐겨찾기에서 삭제하시겠습니까?
+        </p>
+
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            className="flex-1"
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            className="flex-1 bg-red-500 hover:bg-red-600 text-white"
+          >
+            삭제
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/favorite-grid/ui/FavoriteGrid.tsx
+++ b/src/widgets/favorite-grid/ui/FavoriteGrid.tsx
@@ -18,11 +18,13 @@ import {
 import { useFavoritesStore, type FavoriteLocation } from "@/shared/model/favoritesStore";
 import { SortableFavoriteCard } from "./SortableFavoriteCard";
 import { AliasEditModal } from "./AliasEditModal";
+import { DeleteConfirmModal } from "./DeleteConfirmModal";
 import { Star } from "lucide-react";
 
 export function FavoriteGrid() {
   const { favorites, removeFavorite, updateAlias, reorderFavorites } = useFavoritesStore();
   const [editingFavorite, setEditingFavorite] = useState<FavoriteLocation | null>(null);
+  const [deletingFavorite, setDeletingFavorite] = useState<FavoriteLocation | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -39,7 +41,14 @@ export function FavoriteGrid() {
     setEditingFavorite(favorite);
   };
 
-  const handleDelete = (id: string) => {
+  const handleDeleteClick = (id: string) => {
+    const favorite = favorites.find((f) => f.id === id);
+    if (favorite) {
+      setDeletingFavorite(favorite);
+    }
+  };
+
+  const handleDeleteConfirm = (id: string) => {
     removeFavorite(id);
   };
 
@@ -80,7 +89,7 @@ export function FavoriteGrid() {
                 key={favorite.id}
                 favorite={favorite}
                 onEdit={handleEdit}
-                onDelete={handleDelete}
+                onDelete={handleDeleteClick}
               />
             ))}
           </div>
@@ -91,6 +100,12 @@ export function FavoriteGrid() {
         favorite={editingFavorite}
         onClose={() => setEditingFavorite(null)}
         onSave={handleSaveAlias}
+      />
+
+      <DeleteConfirmModal
+        favorite={deletingFavorite}
+        onClose={() => setDeletingFavorite(null)}
+        onConfirm={handleDeleteConfirm}
       />
     </>
   );


### PR DESCRIPTION
  ## Summary
  - 검색 후 로딩 상태가 제대로 표시되지 않던 문제 수정
  - 스크롤바 커스텀 스타일 적용 (시간대별 예보, 검색 드롭다운)
  - 즐겨찾기 삭제 시 확인 모달 추가
  - "현재 위치로" 버튼을 검색창 옆 아이콘 버튼으로 변경
  - 위치 권한 거부 시 기본 위치(서울 강남구) 자동 설정
  - 다크모드 토글 기능 추가

  ## Changes
  | 기능 | 설명 |
  |------|------|
  | 로딩 상태 개선 | 검색 후 날씨 데이터 로딩 중에도 로딩 인디케이터 표시 |
  | 스크롤바 스타일 | `.scrollbar-thin` 클래스로 얇은 스크롤바 적용 |
  | 삭제 확인 모달 | `DeleteConfirmModal` 컴포넌트 추가 |
  | 버튼 위치 조정 | 검색창 옆 아이콘 버튼으로 UI 간소화 |
  | 기본 위치 설정 | 서울 강남구 (37.4979, 127.0276) |
  | 다크모드 | `ThemeToggle` 컴포넌트로 라이트/다크 전환 |

## Screenshot
<img width="515" height="828" alt="image" src="https://github.com/user-attachments/assets/856471c6-71c4-49f3-8de6-248d7d7ea7c9" />


  Closes #12