### PR TITLE
Fix/favorite grid layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,15 +71,6 @@ body {
   }
 }
 
-/* Touch-friendly tap targets */
-@media (pointer: coarse) {
-  button,
-  [role="button"] {
-    min-height: 44px;
-    min-width: 44px;
-  }
-}
-
 /* Text truncation utility */
 .truncate-2-lines {
   display: -webkit-box;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,3 +85,4 @@ body {
     font-size: 14px;
   }
 }
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,15 +70,15 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-[var(--background)] safe-area-bottom">
       {/* 헤더 */}
-      <header className="w-full max-w-md mx-auto p-4 md:p-8 pb-0 flex items-center justify-between">
+      <header className="w-full max-w-md lg:max-w-5xl mx-auto p-4 md:p-8 pb-0 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-[var(--foreground)]">Weather App</h1>
         <ThemeToggle />
       </header>
 
-      <main className="w-full max-w-md mx-auto p-4 md:px-8 flex flex-col gap-4">
+      <main className="w-full max-w-md lg:max-w-5xl mx-auto p-4 md:px-8 flex flex-col gap-4">
         {/* 검색 영역 */}
         <nav aria-label="지역 검색">
-          <div className="flex gap-2">
+          <div className="flex gap-2 lg:max-w-md">
             <div className="flex-1">
               <LocationSearch onSelect={handleLocationSelect} placeholder="지역 검색 (예: 서울, 강남구, 역삼동)" />
             </div>
@@ -99,7 +99,7 @@ export default function Home() {
 
         {/* 알림 메시지 영역 */}
         {locationError && (
-          <aside role="alert" className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-md">
+          <aside role="alert" className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-md lg:max-w-md">
             <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0" aria-hidden="true" />
             <p className="text-sm text-red-500 flex-1">{locationError}</p>
             <button onClick={handleCloseError} className="text-red-500 hover:text-red-400" aria-label="닫기">
@@ -109,7 +109,7 @@ export default function Home() {
         )}
 
         {useDefaultLocation && (
-          <aside role="status" className="flex items-center gap-2 p-3 bg-blue-500/10 border border-blue-500/20 rounded-md">
+          <aside role="status" className="flex items-center gap-2 p-3 bg-blue-500/10 border border-blue-500/20 rounded-md lg:max-w-md">
             <MapPinOff className="w-4 h-4 text-blue-500 flex-shrink-0" aria-hidden="true" />
             <p className="text-sm text-blue-600">
               위치 권한이 거부되어 기본 위치(서울 강남구)를 표시합니다.
@@ -125,23 +125,28 @@ export default function Home() {
           </div>
         )}
 
-        {/* 날씨 정보 섹션 */}
-        {!isSearching && !weatherLoading && weather && currentLat && currentLon && (
-          <section aria-label="현재 날씨">
-            <WeatherCard data={weather} latitude={currentLat} longitude={currentLon} />
-          </section>
-        )}
-        {!isSearching && !weatherLoading && hourly && (
-          <section aria-label="시간대별 예보">
-            <HourlyForecast data={hourly} />
-          </section>
-        )}
+        {/* 2컬럼 레이아웃 (데스크탑) */}
+        <div className="flex flex-col lg:flex-row lg:gap-8 lg:items-start">
+          {/* 왼쪽: 날씨 정보 */}
+          <div className="flex-1 flex flex-col gap-4 lg:max-w-md">
+            {!isSearching && !weatherLoading && weather && currentLat && currentLon && (
+              <section aria-label="현재 날씨">
+                <WeatherCard data={weather} latitude={currentLat} longitude={currentLon} />
+              </section>
+            )}
+            {!isSearching && !weatherLoading && hourly && (
+              <section aria-label="시간대별 예보">
+                <HourlyForecast data={hourly} />
+              </section>
+            )}
+          </div>
 
-        {/* 즐겨찾기 섹션 */}
-        <section className="mt-4 w-full" aria-label="즐겨찾기 목록">
-          <h2 className="text-lg font-semibold mb-3">즐겨찾기</h2>
-          <FavoriteGrid />
-        </section>
+          {/* 오른쪽: 즐겨찾기 (데스크탑에서는 사이드바) */}
+          <section className="mt-4 lg:mt-0 w-full lg:w-80 lg:flex-shrink-0" aria-label="즐겨찾기 목록">
+            <h2 className="text-lg font-semibold mb-3">즐겨찾기</h2>
+            <FavoriteGrid />
+          </section>
+        </div>
       </main>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,38 +68,41 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--background)] safe-area-bottom">
+    <div className="min-h-screen bg-[var(--background)] safe-area-bottom overflow-x-hidden">
       {/* 헤더 */}
-      <header className="w-full max-w-md lg:max-w-5xl mx-auto p-4 md:p-8 pb-0 flex items-center justify-between">
+      <header className="w-full max-w-md lg:max-w-4xl mx-auto p-4 md:p-8 pb-0 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-[var(--foreground)]">Weather App</h1>
         <ThemeToggle />
       </header>
 
-      <main className="w-full max-w-md lg:max-w-5xl mx-auto p-4 md:px-8 flex flex-col gap-4">
-        {/* 검색 영역 */}
-        <nav aria-label="지역 검색">
-          <div className="flex gap-2 lg:max-w-md">
-            <div className="flex-1">
-              <LocationSearch onSelect={handleLocationSelect} placeholder="지역 검색 (예: 서울, 강남구, 역삼동)" />
+      <main className="w-full max-w-md lg:max-w-4xl mx-auto p-4 md:px-8 flex flex-col gap-4">
+        {/* 상단: 검색 + 즐겨찾기 타이틀 */}
+        <div className="flex flex-col lg:flex-row lg:gap-8 lg:items-end">
+          <nav aria-label="지역 검색" className="w-full lg:w-[420px] lg:flex-shrink-0">
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <LocationSearch onSelect={handleLocationSelect} placeholder="지역 검색 (예: 서울, 강남구, 역삼동)" />
+              </div>
+              {selectedLocation && (
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleResetToCurrentLocation}
+                  title="현재 위치로"
+                  aria-label="현재 위치로 돌아가기"
+                  className="flex-shrink-0"
+                >
+                  <Navigation className="w-4 h-4" />
+                </Button>
+              )}
             </div>
-            {selectedLocation && (
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={handleResetToCurrentLocation}
-                title="현재 위치로"
-                aria-label="현재 위치로 돌아가기"
-                className="flex-shrink-0"
-              >
-                <Navigation className="w-4 h-4" />
-              </Button>
-            )}
-          </div>
-        </nav>
+          </nav>
+          <h2 className="hidden lg:block text-lg font-semibold">즐겨찾기</h2>
+        </div>
 
         {/* 알림 메시지 영역 */}
         {locationError && (
-          <aside role="alert" className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-md lg:max-w-md">
+          <aside role="alert" className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-md lg:w-[420px]">
             <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0" aria-hidden="true" />
             <p className="text-sm text-red-500 flex-1">{locationError}</p>
             <button onClick={handleCloseError} className="text-red-500 hover:text-red-400" aria-label="닫기">
@@ -109,7 +112,7 @@ export default function Home() {
         )}
 
         {useDefaultLocation && (
-          <aside role="status" className="flex items-center gap-2 p-3 bg-blue-500/10 border border-blue-500/20 rounded-md lg:max-w-md">
+          <aside role="status" className="flex items-center gap-2 p-3 bg-blue-500/10 border border-blue-500/20 rounded-md lg:w-[420px]">
             <MapPinOff className="w-4 h-4 text-blue-500 flex-shrink-0" aria-hidden="true" />
             <p className="text-sm text-blue-600">
               위치 권한이 거부되어 기본 위치(서울 강남구)를 표시합니다.
@@ -117,18 +120,17 @@ export default function Home() {
           </aside>
         )}
 
-        {/* 로딩 상태 */}
-        {(isSearching || (weatherLoading && (selectedLocation || useDefaultLocation))) && (
-          <div className="flex items-center justify-center gap-2 py-8 text-[var(--muted-foreground)]" role="status" aria-live="polite">
-            <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
-            <span>{isSearching ? "지역 검색 중..." : "날씨 정보 불러오는 중..."}</span>
-          </div>
-        )}
-
         {/* 2컬럼 레이아웃 (데스크탑) */}
         <div className="flex flex-col lg:flex-row lg:gap-8 lg:items-start">
-          {/* 왼쪽: 날씨 정보 */}
-          <div className="flex-1 flex flex-col gap-4 lg:max-w-md">
+          {/* 날씨 정보 */}
+          <div className="flex flex-col gap-4 w-full lg:w-[420px] lg:flex-shrink-0">
+            {/* 로딩 상태 */}
+            {(isSearching || (weatherLoading && (selectedLocation || useDefaultLocation))) && (
+              <div className="flex items-center gap-2 py-8 text-[var(--muted-foreground)]" role="status" aria-live="polite">
+                <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+                <span>{isSearching ? "지역 검색 중..." : "날씨 정보 불러오는 중..."}</span>
+              </div>
+            )}
             {!isSearching && !weatherLoading && weather && currentLat && currentLon && (
               <section aria-label="현재 날씨">
                 <WeatherCard data={weather} latitude={currentLat} longitude={currentLon} />
@@ -141,9 +143,9 @@ export default function Home() {
             )}
           </div>
 
-          {/* 오른쪽: 즐겨찾기 (데스크탑에서는 사이드바) */}
-          <section className="mt-4 lg:mt-0 w-full lg:w-80 lg:flex-shrink-0" aria-label="즐겨찾기 목록">
-            <h2 className="text-lg font-semibold mb-3">즐겨찾기</h2>
+          {/* 즐겨찾기 */}
+          <section className="mt-6 lg:mt-0 w-full lg:flex-1" aria-label="즐겨찾기 목록">
+            <h2 className="lg:hidden text-lg font-semibold mb-3">즐겨찾기</h2>
             <FavoriteGrid />
           </section>
         </div>

--- a/src/features/weather/api/weatherApi.ts
+++ b/src/features/weather/api/weatherApi.ts
@@ -213,9 +213,6 @@ export async function reverseGeocode(
     const data: NominatimResponse = await response.json();
     const address = data.address;
 
-    // 디버깅: Nominatim 응답 확인
-    console.log("Nominatim response:", JSON.stringify(address, null, 2));
-
     // 전체 주소 조합: 도/시 + 시/군/구 + 동/읍/면
     const parts: string[] = [];
 

--- a/src/widgets/favorite-grid/ui/FavoriteGrid.tsx
+++ b/src/widgets/favorite-grid/ui/FavoriteGrid.tsx
@@ -83,7 +83,13 @@ export function FavoriteGrid() {
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={favorites.map((f) => f.id)} strategy={rectSortingStrategy}>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: '12px',
+            }}
+          >
             {favorites.map((favorite) => (
               <SortableFavoriteCard
                 key={favorite.id}


### PR DESCRIPTION
  ## Summary
  - 즐겨찾기 그리드가 세로로 표시되는 버그 수정 (TailwindCSS v4 호환성 이슈)
  - 데스크탑 뷰에서 2컬럼 반응형 레이아웃 구현
  - 불필요한 console.log 제거

  ## Changes
  - **즐겨찾기 그리드**: TailwindCSS v4에서 `grid-cols-2` 클래스가 동작하지 않아 inline style로 변경
  - **데스크탑 레이아웃**: 날씨 정보(좌측) + 즐겨찾기(우측) 2컬럼 배치
  - **정렬 개선**: 검색창-즐겨찾기 타이틀, 날씨 카드-즐겨찾기 카드 상단 정렬
  - **로딩 상태**: 로딩 중에도 2컬럼 레이아웃 유지
  - **코드 정리**: weatherApi.ts에서 Nominatim 응답 console.log 제거
  
  
  Closes #18